### PR TITLE
Properly pass filename to `:wundo`.

### DIFF
--- a/autoload/SudoEdit.vim
+++ b/autoload/SudoEdit.vim
@@ -146,7 +146,6 @@ fu! SudoEdit#SudoDo(readflag, file) range "{{{2
     let file = !empty(a:file) ? substitute(a:file, '^sudo:', '', '') : expand("%")
     if empty(file)
 	call SudoEdit#echoWarn("Cannot write file. Please enter filename for writing!")
-	call SudoEdit#LocalSettings(0)
 	return
     endif
     if a:readflag


### PR DESCRIPTION
Also, do not catch any error, but display them as is.

Closes #5.
