### PR TITLE
Add shm+=A guard around :f

### DIFF
--- a/autoload/SudoEdit.vim
+++ b/autoload/SudoEdit.vim
@@ -300,7 +300,10 @@ fu! <sid>SudoWrite(file) range "{{{2
         if empty(glob(a:file))
             let s:new_file = 1
         endif
+        let sshm = &shortmess
+        set shortmess+=A  " don't give the "ATTENTION" message when an existing swap file is found.
         exe "f" fnameescape(a:file)
+        let &shortmess = sshm
         call <sid>Exec(cmd)
     endif
     if v:shell_error


### PR DESCRIPTION
This is required to prevent the "ATTENTION" message / exception with
`:file`.

Fixes https://github.com/chrisbra/SudoEdit.vim/issues/26
