### PR TITLE
Fix a couple of typos/spelling errors in the documentation (authtication, commandline, is is, whishlist)

### DIFF
--- a/README
+++ b/README
@@ -250,7 +250,7 @@ work, set the 'undodir' option to a directory, that is writable.
 5) Great work!
 
 Write me an email (look in the first line for my mail address). And if you are
-really happy, vote for the plugin and consider looking at my Amazon whishlist:
+really happy, vote for the plugin and consider looking at my Amazon wish list:
 http://www.amazon.de/wishlist/2BKAHE8J7Z6UW
 
 6) Plugin Feedback                                        *SudoEdit-feedback*

--- a/doc/SudoEdit.txt
+++ b/doc/SudoEdit.txt
@@ -253,7 +253,7 @@ work, set the 'undodir' option to a directory, that is writable.
 5) Great work!
 
 Write me an email (look in the first line for my mail address). And if you are
-really happy, vote for the plugin and consider looking at my Amazon whishlist:
+really happy, vote for the plugin and consider looking at my Amazon wish list:
 http://www.amazon.de/wishlist/2BKAHE8J7Z6UW
 
 6) Plugin Feedback                                        *SudoEdit-feedback*


### PR DESCRIPTION
Thanks for creating this nifty plugin! I don't have to use it often, but it oh so handy when you really need it.

Here's a few typo fixes I discovered when reading the docs. Not all instances of 'authtication' was fixed by #28 it seems, but now it should be resolved. 

Might be worth looking into a solution that doesn't seperate `doc/SudoEdit.txt` and `README` though, or automaticaly keeps them identical. I haven't written a plugin before nor a vimball so I won't comment on how it should be done. 
