### PR TITLE
RFC: keep 'readonly' setting

### DIFF
--- a/autoload/SudoEdit.vim
+++ b/autoload/SudoEdit.vim
@@ -231,7 +231,11 @@ fu! <sid>LocalSettings(values, readflag, file) "{{{2
 
             " Call undojoin, but catch 'undojoin is not allowed after undo'.
             try | undojoin | catch /^Vim\%((\a\+)\)\=:E790/ | endtry
+            let orig_readonly = &readonly
             exe "edit" fnameescape(file)
+            if &readonly != orig_readonly
+                let &readonly = orig_readonly
+            endif
             "let &ur=_ur
             " Reset old settings
             let [ &srr, &l:ar, &t_ti, &t_te, &shell, &stmp, &ssl, &ur, &mls ] = values


### PR DESCRIPTION
`:edit` seems to reset this always.

This helps when writing a non-user buffer often, but Vim will still ask
about confirmation due to file permissions anyway [1].
Therefore the best seems to use `:w!` then right away, which also makes
this patch unnecessary.

But it might still be sensible to keep the `'readonly'` setting (when it
was changed).

1: https://github.com/vim/vim/commit/5386a123f (patch 7.1.017, have not
   checked current code)