### PR TITLE
Create an empty error file to ensure it is owned by the user

### DIFF
--- a/autoload/SudoEdit.vim
+++ b/autoload/SudoEdit.vim
@@ -88,6 +88,9 @@ fu! <sid>Init() "{{{2
             let s:error_file = s:error_dir. s:slash. 'error'
             let s:error_file = fnamemodify(s:error_file, ':p:8')
         endif
+        " Create the empty error file already, to ensure it is owned by the
+        " current user.
+        call writefile([], s:error_file)
     endif
     " Reset skip writing undo files
     let s:skip_wundo = 0


### PR DESCRIPTION
After `:SudoEdit` first worked, it then failed:

> There was an error writing the file!

The command being run is: `SUDO_ASKPASS='/usr/lib/ssh/x11-ssh-askpass'
sudo -A  tee >/dev/null 2>'/tmp/nvimomN45m/17/error' '/usr/lib/…', but
`/tmp/nvimomN45m/17/error` (`s:error_file`) was not writable:

> -rw-r--r-- 1 root root 0 Feb 26 15:14 /tmp/nvimomN45m/17/error

This was likely created when handling the undo file [1].

1: https://github.com/chrisbra/SudoEdit.vim/blob/62c76e367/autoload/SudoEdit.vim#L198-L202