### PR TITLE
Get rid of the 8.3 trick to address issue #61

### DIFF
--- a/autoload/SudoEdit.vim
+++ b/autoload/SudoEdit.vim
@@ -70,7 +70,7 @@ fu! <sid>Init() "{{{2
             " easily
             let s:writable_file = (empty($PUBLIC) ? $TEMP : $PUBLIC ).
                         \ s:slash. 'vim_temp_'.getpid().'.txt'
-            let s:writable_file = shellescape(fnamemodify(s:writable_file, ':p:8'))
+                        let s:writable_file = shellescape(s:writable_file)
         endif
     else
         if !exists("s:writable_file")
@@ -86,7 +86,7 @@ fu! <sid>Init() "{{{2
         let s:error_file = s:error_dir. '/error'
         if <sid>Is("win")
             let s:error_file = s:error_dir. s:slash. 'error'
-            let s:error_file = fnamemodify(s:error_file, ':p:8')
+            " let s:error_file = fnamemodify(s:error_file, ':p:8')
         endif
         " Create the empty error file already, to ensure it is owned by the
         " current user.
@@ -275,7 +275,7 @@ fu! <sid>SudoRead(file) "{{{2
     sil %d _
     if <sid>Is("win")
         " Use Windows Shortnames (should makeing quoting easy)
-        let file = shellescape(fnamemodify(a:file, ':p:8'))
+        let file = shellescape(a:file)
         let cmd  = printf('!%s%s%s%s read %s %s %s', 
                 \ (s:IsUAC ? 'start /B cmd /c "wscript.exe ':''), s:dir, s:slash,
                 \ (s:IsUAC ? 'SudoEdit.vbs' : 'sudo.cmd'),
@@ -326,7 +326,7 @@ fu! <sid>SudoWrite(file) range "{{{2
     else
         if <sid>Is("win")
             exe 'sil keepalt noa '. a:firstline . ',' . a:lastline . 'w! ' . s:writable_file[1:-2]
-            let file = shellescape(fnamemodify(file, ':p:8'))
+            let file = shellescape(file)
             " Do not try to understand the funny quotes...
             " That looks unreadable currently...
             let cmd= printf('!%s%s%s%s write %s %s %s',

--- a/autoload/sudo.cmd
+++ b/autoload/sudo.cmd
@@ -11,7 +11,7 @@ shift
 shift
 shift
 
-:: Use runas or something alike to elevate priviliges, but
+:: Use runas or something alike to elevate privileges, but
 :: first parse parameter for runas
 :: Windows cmd.exe is very clumsy to use ;(
 set params=%1
@@ -29,8 +29,10 @@ echo ***************************************
 echo Calling %sudo% for Privilege Escalation
 echo ***************************************
 if '%mode%' == 'write' (
-    %sudo% %params% " %COMSPEC% /c copy /Y %newcontent% %myfile% "
+    :: echo %sudo% %params% "%COMSPEC% /c copy /Y \"%newcontent:"=%\" \"%myfile:"=%\""
+    %sudo% %params% "%COMSPEC% /c copy /Y \"%newcontent:"\"=% \"%myfile:"=%\""
 ) else (
-    %sudo% %params% " %COMSPEC% /c copy /Y %myfile% %newcontent% "
+    :: echo %sudo% %params% "%COMSPEC% /c copy /Y \"%myfile:"="%\" \"%newcontent:"="%\""
+    %sudo% %params% "%COMSPEC% /c copy /Y \"%myfile:"="%\" \"%newcontent:"="%\""
 )
 exit /B %ERRORLEVEL%


### PR DESCRIPTION
Hi Christian,

Here are the changes I propose to get rid of the 8.3 trick that strip part of the path.

Remark: Unfortunately it does solves all my problems because to change `C:\Windows\System32\Drivers\etc\hosts` I need another user and to run in elevated mode and it seems that runas do only the first part and not the second.

Best regards,
Vivian.