### PR TITLE
Automatically SudoWrite on save readonly file

### DIFF
--- a/plugin/SudoEdit.vim
+++ b/plugin/SudoEdit.vim
@@ -72,6 +72,7 @@ augroup Sudo
 	autocmd!
 	au BufReadCmd,FileReadCmd sudo:/*,sudo:* SudoRead <afile>
 	au BufWriteCmd,FileWriteCmd sudo:/*,sudo:* SudoWrite <afile>
+	au FileChangedRO * set noreadonly | execute "autocmd BufWriteCmd <buffer> SudoWrite"
 augroup END
 "}}}
 


### PR DESCRIPTION
Fixes #63

The default behaviour was to give an error stating the file is readonly, both when editing and when saving the file. Instead, we now just call SudoWrite and forego the buffer write.