### PR TITLE
BUG: Regression: Plugin also triggers on writable read-only files

### DIFF
--- a/plugin/SudoEdit.vim
+++ b/plugin/SudoEdit.vim
@@ -72,7 +72,7 @@ augroup Sudo
 	autocmd!
 	au BufReadCmd,FileReadCmd sudo:/*,sudo:* SudoRead <afile>
 	au BufWriteCmd,FileWriteCmd sudo:/*,sudo:* SudoWrite <afile>
-	au FileChangedRO * set noreadonly | execute "autocmd BufWriteCmd <buffer> SudoWrite"
+	au FileChangedRO * if !filewritable(expand('<afile>')) | set noreadonly | execute "autocmd BufWriteCmd <buffer> SudoWrite" | endif
 augroup END
 "}}}
 


### PR DESCRIPTION
I frequently use `:view` instead of `:edit` to open a file as read-only, but then might decide to start editing, and can do so with a simple `:w!` (which resets the `'readonly'` flag). After updating SudoEdit, the plugin now kicks in (repeatedly, on each write) even when I have full access control to the file!

I think that was not the intention of #64. This adds a check for writability to the added `FileChangedRO` event handler and skips the plugin activation if the file can be written to.
